### PR TITLE
[추가] UserGroupMapping 엔티티, 복합키 추가

### DIFF
--- a/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingEntity.java
+++ b/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingEntity.java
@@ -1,0 +1,36 @@
+package com.marathon.passbatch.repository.user;
+
+
+import com.marathon.passbatch.repository.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "user_group_mapping")
+@IdClass(UserGroupMappingId.class)
+public class UserGroupMappingEntity extends BaseEntity {
+
+    /**
+     * 사용자가 속한 사용자그룹을 보여주는 엔티티
+     * 이 엔티티는 사용자들을 그룹화 시켜 관리하기 위한 엔티티이다.
+     *
+     * 복합키 선언 : @IdClass 어노테이션 선언을 하여 복합키를 설정한다.
+     * */
+
+    @Id
+    private String userGroupId;
+    @Id
+    private String userId;
+
+    private String userGroupName;
+    private String description;
+
+}

--- a/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingEntity_T.java
+++ b/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingEntity_T.java
@@ -1,0 +1,30 @@
+package com.marathon.passbatch.repository.user;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.IdClass;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+@Entity
+@Table(name = "user_group_mapping")
+@IdClass(UserGroupMappingId_T.class)
+public class UserGroupMappingEntity_T {
+
+    @Id
+    private Integer userGroupId;
+
+    @Id
+    private Integer userId;
+
+    private String userGroupName;
+    private String description;
+
+}

--- a/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingId.java
+++ b/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingId.java
@@ -1,0 +1,21 @@
+package com.marathon.passbatch.repository.user;
+
+import java.io.Serializable;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString
+public class UserGroupMappingId implements Serializable {
+
+    /**
+     * 복합키 클래스를 만들기 위해서는 Serializable을 구현해야한다.
+     * */
+
+    private String userGroupId;
+    private String userId;
+
+}

--- a/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingId_T.java
+++ b/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingId_T.java
@@ -1,0 +1,18 @@
+package com.marathon.passbatch.repository.user;
+
+import java.io.Serializable;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+
+@Getter
+@Setter
+@ToString
+public class UserGroupMappingId_T implements Serializable {
+
+    private Integer userGroupId;
+    private Integer userId;
+
+}

--- a/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingRepository.java
+++ b/src/main/java/com/marathon/passbatch/repository/user/UserGroupMappingRepository.java
@@ -1,0 +1,11 @@
+package com.marathon.passbatch.repository.user;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserGroupMappingRepository extends JpaRepository<UserGroupMappingEntity, Integer> {
+
+    List<UserGroupMappingEntity> findByUserGroupId(String userGroupId);
+
+}


### PR DESCRIPTION
- UserGroupMappingEntity : 사용자 그룹 엔티티이다. 이 엔티티를 생성하는 이유는 사용자들을 보다 쉽게 관리하기 위해서 사용자그룹을 만든 것이다. 이용권 만료처리를 일괄로 갱신하기 위해서 사용자그룹을 만듬
- UserGroupMappingId : 사용자그룹엔티티의 복합키를 위해서 생성. 사용자그룹ID, 사용자ID가 복합키로 설정